### PR TITLE
fix json format error for using swd interface

### DIFF
--- a/main/web/website.html
+++ b/main/web/website.html
@@ -469,7 +469,7 @@
       function sendOpenocdConfig() {
         // Get the form inputs
         var target = document.getElementById("config").value;
-        var interface = document.getElementById("interface").value;
+        var interface = parseInt(document.getElementById("interface").value);
         var rtos = document.getElementById("rtos").value;
         var debug = document.getElementById("debug").value;
         var dualCore = document.getElementById("dual-core").checked;


### PR DESCRIPTION
found a bug in swd mode. interface value in json should be an interger type but the web generate a string type. It cause the error decode in esp32 device, and still select jtag interface 